### PR TITLE
Add support to replace teardown with after

### DIFF
--- a/lib/minitest_converter/converters/shoulda.rb
+++ b/lib/minitest_converter/converters/shoulda.rb
@@ -23,6 +23,7 @@ module MinitestConverter
         convert_context_to_describe
         convert_should_to_it
         convert_setup_to_before
+        convert_teardown_to_after
 
         @content
       end
@@ -57,6 +58,11 @@ module MinitestConverter
       def convert_setup_to_before
         @content.gsub!(/setup do/, 'before do')
         @content.gsub!(/setup {/, 'before {')
+      end
+
+      def convert_teardown_to_after
+        @content.gsub!(/teardown do/, 'after do')
+        @content.gsub!(/teardown {/, 'after {')
       end
 
       def convert_should_to_it

--- a/spec/files/teardown_blocks.rb
+++ b/spec/files/teardown_blocks.rb
@@ -1,0 +1,5 @@
+teardown do
+  something = 'test'
+end
+
+teardown { something = 'test' }

--- a/spec/minitest_converter_spec.rb
+++ b/spec/minitest_converter_spec.rb
@@ -41,4 +41,13 @@ describe MinitestConverter::Converter do
       expect(File.read(file)).to eq("before do\n  something = 'test'\nend\n\nbefore { something = 'test' }\n")
     end
   end
+
+  it 'converts teardown blocks to after format' do
+    file = 'spec/files/setup_blocks.rb'
+    revert file do
+      converter = MinitestConverter::Converter.new(file)
+      converter.convert!
+      expect(File.read(file)).to eq("after do\n  something = 'test'\nend\n\nafter { something = 'test' }\n")
+    end
+  end
 end


### PR DESCRIPTION
@jespr adds support to replace `teardown` with `after`
